### PR TITLE
Add support for podman

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,9 @@
 - Docker installed
 - Docker-Compose installed (Version 1.26.0 or higher)
 
+If you would like to use another container engine, feel free to do so. All images are OCI compliant and have their respective container registry explicitly named in the compose file. 
+The whole stack was successfully tested using podman and podman-compose. Just replace the `docker-compose [...]` commands listed below with `podman-compose [...]`
+
 ## Installation
 
 We highly recommend to set up your own environment first. This can be done by starting from the example environment: `cp .env.example .env`

--- a/config/ensembl_rest.conf
+++ b/config/ensembl_rest.conf
@@ -288,7 +288,7 @@ jsonp=1
 
 <Controller::VEP>
 # Supply a fasta path for Human in order to allow VEP to work locally
-  fasta             = /opt/vep/.vep/homo_sapiens/103_GRCh37/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz # path to Human toplevel fasta file
+  fasta             = /opt/vep/.vep/homo_sapiens/110_GRCh37/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz # path to Human toplevel fasta file
   dir               = /opt/vep/.vep # path to the vep cache directory
 # Default parameters for running vep
   cache_region_size = 1000000

--- a/data/init.sh
+++ b/data/init.sh
@@ -1,2 +1,2 @@
 # Download the seed database
-wget "https://raw.githubusercontent.com/cBioPortal/cbioportal/v3.6.10/db-scripts/src/main/resources/cgds.sql" -O cgds.sql && wget "https://github.com/cBioPortal/datahub/raw/master/seedDB/seed-cbioportal_hg19_v2.12.8.sql.gz" -O seed-cbioportal_hg19_v2.12.8.sql.gz
+wget "https://raw.githubusercontent.com/cBioPortal/cbioportal/v3.6.10/db-scripts/src/main/resources/cgds.sql" -O cgds.sql && wget "https://github.com/cBioPortal/datahub/raw/519d113153acb69b4bd7f9ad913550b234d1cbf7/seedDB/seedDB_hg19_archive/seed-cbioportal_hg19_v2.12.8.sql.gz" -O seed-cbioportal_hg19_v2.12.8.sql.gz

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -28,7 +28,7 @@ services:
       - "8081:8080"
     networks:
      - cbioportal_net
-    command: [ 
+    command: [
       "/usr/bin/java",
       "-Xmx4g",
       "-Xdebug",
@@ -69,7 +69,7 @@ services:
     ]
   cbioportal_database:
     restart: unless-stopped
-    image: mariadb:10.8.2
+    image: docker.io/mariadb:10.8.2
     container_name: cbioportal_database_container
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-P@ssword1}
@@ -90,7 +90,7 @@ services:
      - cbioportal_net
   cbioportal-session:
     restart: unless-stopped
-    image: cbioportal/session-service:0.5.0
+    image: docker.io/cbioportal/session-service:0.5.0
     container_name: cbioportal_session_container
     environment:
       SERVER_PORT: 5000
@@ -103,7 +103,7 @@ services:
       - cbioportal_net
   cbioportal-session-database:
     restart: unless-stopped
-    image: mongo:3.7.9
+    image: docker.io/mongo:3.7.9
     container_name: cbioportal_session_database_container
     environment:
       MONGO_INITDB_DATABASE: session_service
@@ -134,7 +134,7 @@ services:
       - cbioportal_net
   hapiserver:
     restart: unless-stopped
-    image: hapiproject/hapi:v6.1.0
+    image: docker.io/hapiproject/hapi:v6.1.0
     container_name: cbioportal_fhirspark_hapiserver
     ports:
       - "8082:8080"
@@ -154,7 +154,7 @@ services:
       - cbioportal_net
   hapi-postgres:
     restart: unless-stopped
-    image: postgres:14.5-alpine
+    image: docker.io/postgres:14.5-alpine
     container_name: cbioportal_fhirspark_database
     volumes:
       - fhir_data:/var/lib/postgresql/data
@@ -236,7 +236,7 @@ services:
     networks:
       - cbioportal_net
   ensembl-rest:
-    image: nr205/ensembl-rest:${RELEASE:-latest}
+    image: docker.io/nr205/ensembl-rest:109
     restart: unless-stopped
     ports:
       - "8083:3000"
@@ -253,8 +253,8 @@ services:
       - cbioportal_net
 
 networks:
-  cbioportal_net: 
-  
+  cbioportal_net:
+
 volumes:
   cbioportal_data:
   cbioportal_session_data:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -237,7 +237,7 @@ services:
     networks:
       - cbioportal_net
   ensembl-rest:
-    image: docker.io/nr205/ensembl-rest:109
+    image: docker.io/nr205/ensembl-rest:110
     restart: unless-stopped
     ports:
       - "8083:3000"

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -13,13 +13,13 @@ services:
       DB_PASSWORD: ${MYSQL_USER_PASSWORD:-P@ssword1}
       SHOW_DEBUG_INFO: "true"
     volumes:
-     - ./study:/study/
-     - ./config/portal.properties:/cbioportal/portal.properties:ro
-     - ./config/client-tailored-saml-idp-metadata.xml:/cbioportal-webapp/WEB-INF/classes/client-tailored-saml-idp-metadata.xml
-     - ./config/samlKeystore.jks:/cbioportal-webapp/WEB-INF/classes/samlKeystore.jks
-     - ./config/frontend.json:/cbioportal/frontend.json:ro
-     - ./config/${LOGO:-miracum.png}:/cbioportal-webapp/images/${LOGO:-miracum.png}
-     - cbioportal_portalinfo:/cbioportal/portalinfo
+     - ./study:/study/:z
+     - ./config/portal.properties:/cbioportal/portal.properties:Z
+     - ./config/client-tailored-saml-idp-metadata.xml:/cbioportal-webapp/WEB-INF/classes/client-tailored-saml-idp-metadata.xml:Z
+     - ./config/samlKeystore.jks:/cbioportal-webapp/WEB-INF/classes/samlKeystore.jks:Z
+     - ./config/frontend.json:/cbioportal/frontend.json:Z
+     - ./config/${LOGO:-miracum.png}:/cbioportal-webapp/images/${LOGO:-miracum.png}:Z
+     - cbioportal_portalinfo:/cbioportal/portalinfo:z
     depends_on:
      - cbioportal_database
      - cbioportal-session
@@ -30,6 +30,7 @@ services:
      - cbioportal_net
     command: [
       "/usr/bin/java",
+      "-Xms2g",
       "-Xmx4g",
       "-Xdebug",
       "-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=*:5005",
@@ -77,9 +78,9 @@ services:
       MYSQL_USER: cbio
       MYSQL_PASSWORD: ${MYSQL_USER_PASSWORD:-P@ssword1}
     volumes:
-     - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:ro
-     - ./data/seed-cbioportal_hg19_v2.12.8.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:ro
-     - ./data/tableExtension.sql:/docker-entrypoint-initdb.d/tableExtension.sql:ro
+     - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:Z
+     - ./data/seed-cbioportal_hg19_v2.12.8.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:Z
+     - ./data/tableExtension.sql:/docker-entrypoint-initdb.d/tableExtension.sql:Z
      - cbioportal_data:/var/lib/mysql
     command:
      - --character-set-server=latin1
@@ -122,12 +123,12 @@ services:
     depends_on:
       - hapiserver
     environment:
-      FHIRSPARK_FHIRBASE: http://hapiserver:8080/fhir/
+      FHIRSPARK_FHIRBASE: http://hapiserver:8080/fhir
       FHIRSPARK_PORTALURL: http://cbioportal:8080/
       FHIRSPARK_LOGINREQUIRED: ${LOGINREQUIRED:-false}
     volumes:
-      - ./data/drugs.json:/drugs.json:ro
-      - ./data/hgnc.csv:/hgnc.csv:ro
+      - ./data/drugs.json:/drugs.json:Z
+      - ./data/hgnc.csv:/hgnc.csv:Z
     ports:
       - "3001:3001"
     networks:
@@ -173,17 +174,17 @@ services:
       context: services/cbioproxy
     container_name: cbioproxy_container
     volumes:
-      - ./services/cbioproxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
-      - ./services/cbioproxy/cbioportal.conf:/etc/nginx/conf.d/cbioportal.conf
-      - ./services/cbioproxy/lua_auth_config.lua:/etc/nginx/conf.d/lua_auth_config.lua
-      - ./services/cbioproxy/lua_login_config.lua:/etc/nginx/conf.d/lua_login_config.lua
-      - ./services/cbioproxy/lua_resource_config.lua:/etc/nginx/conf.d/lua_resource_config.lua
-      - ./reports:/usr/share/reports
-      - ./config/attributes.json:/attributes.json
-      - ./data/tumorTypes.json:/tumorTypes.json
-      - ./config/certs:/certs
+      - ./services/cbioproxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:Z
+      - ./services/cbioproxy/cbioportal.conf:/etc/nginx/conf.d/cbioportal.conf:Z
+      - ./services/cbioproxy/lua_auth_config.lua:/etc/nginx/conf.d/lua_auth_config.lua:Z
+      - ./services/cbioproxy/lua_login_config.lua:/etc/nginx/conf.d/lua_login_config.lua:Z
+      - ./services/cbioproxy/lua_resource_config.lua:/etc/nginx/conf.d/lua_resource_config.lua:Z
+      - ./reports:/usr/share/reports:Z
+      - ./config/attributes.json:/attributes.json:Z
+      - ./data/tumorTypes.json:/tumorTypes.json:Z
+      - ./config/certs:/certs:z
     environment:
-      NGINX_LOGINREQUIRED: ${LOGINREQUIRED:-true}
+      NGINX_LOGINREQUIRED: ${LOGINREQUIRED:-false}
       KEYCLOAK_URL: ${KEYCLOAK_URL:-//localhost:8080}
       KEYCLOAK_REALM: ${KEYCLOAK_REALM:-master}
       KEYCLOAK_CLIENT: ${KEYCLOAK_CLIENT:-fhirspark}
@@ -241,7 +242,7 @@ services:
     ports:
       - "8083:3000"
     volumes:
-      - ./config/ensembl_rest.conf:/opt/vep/src/ensembl-rest/ensembl_rest.conf
+      - ./config/ensembl_rest.conf:/opt/vep/src/ensembl-rest/ensembl_rest.conf:Z
     networks:
       - cbioportal_net
     depends_on:

--- a/docker-compose-research.yml
+++ b/docker-compose-research.yml
@@ -150,7 +150,7 @@ services:
     networks:
       - cbioportal_net
   ensembl-rest:
-    image: nr205/ensembl-rest:109
+    image: nr205/ensembl-rest:110
     restart: unless-stopped
     volumes:
       - ./config/ensembl_rest.conf:/opt/vep/src/ensembl-rest/ensembl_rest.conf:Z

--- a/docker-compose-research.yml
+++ b/docker-compose-research.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   cbioportal:
     restart: unless-stopped
-    image: cbioportal/cbioportal:4.1.13
+    image: docker.io/cbioportal/cbioportal:4.1.13
     container_name: cbioportal_container
     environment:
       HTTP_PROXY: "http://${HTTPS_PROXY_HOST}:${HTTPS_PROXY_PORT}"
@@ -21,7 +21,7 @@ services:
      - cbioportal-session
     networks:
      - cbioportal_net
-    command: [ 
+    command: [
       "java",
       "-Xms2g",
       "-Xmx4g",
@@ -60,7 +60,7 @@ services:
     ]
   cbioportal_database:
     restart: unless-stopped
-    image: mariadb:10.8.2
+    image: docker.io/mariadb:10.8.2
     container_name: cbioportal_database_container
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-P@ssword1}
@@ -79,7 +79,7 @@ services:
      - cbioportal_net
   cbioportal-session:
     restart: unless-stopped
-    image: cbioportal/session-service:0.5.0
+    image: docker.io/cbioportal/session-service:0.5.0
     container_name: cbioportal_session_container
     environment:
       SERVER_PORT: 5000
@@ -90,7 +90,7 @@ services:
       - cbioportal_net
   cbioportal-session-database:
     restart: unless-stopped
-    image: mongo:3.7.9
+    image: docker.io/mongo:3.7.9
     container_name: cbioportal_session_database_container
     environment:
       MONGO_INITDB_DATABASE: session_service
@@ -165,8 +165,8 @@ services:
       - cbioportal_net
 
 networks:
-  cbioportal_net: 
-  
+  cbioportal_net:
+
 volumes:
   cbioportal_data:
   cbioportal_session_data:

--- a/docker-compose-research.yml
+++ b/docker-compose-research.yml
@@ -10,12 +10,12 @@ services:
       NO_PROXY: "cbioportal,cbioportal_session"
       DB_PASSWORD: ${MYSQL_USER_PASSWORD:-P@ssword1}
     volumes:
-     - ./study:/study/
-     - ./config/portal.properties:/cbioportal/portal.properties:ro
-     - ./config/client-tailored-saml-idp-metadata.xml:/cbioportal-webapp/WEB-INF/classes/client-tailored-saml-idp-metadata.xml
-     - ./config/samlKeystore.jks:/cbioportal-webapp/WEB-INF/classes/samlKeystore.jks
-     - ./config/${LOGO:-miracum.png}:/cbioportal-webapp/images/${LOGO:-miracum.png}
-     - cbioportal_portalinfo:/cbioportal/portalinfo
+     - ./study:/study/:z
+     - ./config/portal.properties:/cbioportal/portal.properties:Z
+     - ./config/client-tailored-saml-idp-metadata.xml:/cbioportal-webapp/WEB-INF/classes/client-tailored-saml-idp-metadata.xml:Z
+     - ./config/samlKeystore.jks:/cbioportal-webapp/WEB-INF/classes/samlKeystore.jks:Z
+     - ./config/${LOGO:-miracum.png}:/cbioportal-webapp/images/${LOGO:-miracum.png}:Z
+     - cbioportal_portalinfo:/cbioportal/portalinfo:z
     depends_on:
      - cbioportal_database
      - cbioportal-session
@@ -68,9 +68,9 @@ services:
       MYSQL_USER: cbio
       MYSQL_PASSWORD: ${MYSQL_USER_PASSWORD:-P@ssword1}
     volumes:
-     - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:ro
-     - ./data/seed-cbioportal_hg19_v2.12.8.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:ro
-     - ./data/tableExtension.sql:/docker-entrypoint-initdb.d/tableExtension.sql:ro
+     - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:Z
+     - ./data/seed-cbioportal_hg19_v2.12.8.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:Z
+     - ./data/tableExtension.sql:/docker-entrypoint-initdb.d/tableExtension.sql:Z
      - cbioportal_data:/var/lib/mysql
     command:
      - --character-set-server=latin1
@@ -105,11 +105,11 @@ services:
       NGINX_LOGINREQUIRED: ${LOGINREQUIRED:-false}
     container_name: cbioproxy_container
     volumes:
-      - ./services/cbioproxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
-      - ./services/cbioproxy/cbioportal-research.conf:/etc/nginx/conf.d/cbioportal.conf
-      - ./services/cbioproxy/lua_resource_config.lua:/etc/nginx/conf.d/lua_resource_config.lua
-      - ./reports:/usr/share/reports
-      - ./config/certs:/certs
+      - ./services/cbioproxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:Z
+      - ./services/cbioproxy/cbioportal-research.conf:/etc/nginx/conf.d/cbioportal.conf:Z
+      - ./services/cbioproxy/lua_resource_config.lua:/etc/nginx/conf.d/lua_resource_config.lua:Z
+      - ./reports:/usr/share/reports:Z
+      - ./config/certs:/certs:z
     ports:
       - "${PORT:-8080}:8080"
     depends_on:
@@ -150,10 +150,10 @@ services:
     networks:
       - cbioportal_net
   ensembl-rest:
-    image: nr205/ensembl-rest:${RELEASE:-latest}
+    image: nr205/ensembl-rest:109
     restart: unless-stopped
     volumes:
-      - ./config/ensembl_rest.conf:/opt/vep/src/ensembl-rest/ensembl_rest.conf
+      - ./config/ensembl_rest.conf:/opt/vep/src/ensembl-rest/ensembl_rest.conf:Z
     networks:
       - cbioportal_net
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
      - cbioportal-session
     networks:
      - cbioportal_net
-    command: [ 
+    command: [
       "/usr/bin/java",
       "-Xms2g",
       "-Xmx4g",
@@ -62,7 +62,7 @@ services:
     ]
   cbioportal_database:
     restart: unless-stopped
-    image: mariadb:10.8.2
+    image: docker.io/mariadb:10.8.2
     container_name: cbioportal_database_container
     environment:
       MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-P@ssword1}
@@ -81,7 +81,7 @@ services:
      - cbioportal_net
   cbioportal-session:
     restart: unless-stopped
-    image: cbioportal/session-service:0.5.0
+    image: docker.io/cbioportal/session-service:0.5.0
     container_name: cbioportal_session_container
     environment:
       SERVER_PORT: 5000
@@ -92,7 +92,7 @@ services:
       - cbioportal_net
   cbioportal-session-database:
     restart: unless-stopped
-    image: mongo:3.7.9
+    image: docker.io/mongo:3.7.9
     container_name: cbioportal_session_database_container
     environment:
       MONGO_INITDB_DATABASE: session_service
@@ -117,7 +117,7 @@ services:
       - cbioportal_net
   hapiserver:
     restart: unless-stopped
-    image: hapiproject/hapi:v6.1.0
+    image: docker.io/hapiproject/hapi:v6.1.0
     container_name: cbioportal_fhirspark_hapiserver
     depends_on:
       - hapi-postgres
@@ -135,7 +135,7 @@ services:
       - cbioportal_net
   hapi-postgres:
     restart: unless-stopped
-    image: postgres:14.5-alpine
+    image: docker.io/postgres:14.5-alpine
     container_name: cbioportal_fhirspark_database
     volumes:
       - fhir_data:/var/lib/postgresql/data
@@ -207,7 +207,7 @@ services:
     networks:
       - cbioportal_net
   ensembl-rest:
-    image: nr205/ensembl-rest:${RELEASE:-latest}
+    image: docker.io/nr205/ensembl-rest:109
     restart: unless-stopped
     volumes:
       - ./config/ensembl_rest.conf:/opt/vep/src/ensembl-rest/ensembl_rest.conf
@@ -222,8 +222,8 @@ services:
       - cbioportal_net
 
 networks:
-  cbioportal_net: 
-  
+  cbioportal_net:
+
 volumes:
   cbioportal_data:
   cbioportal_session_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -207,7 +207,7 @@ services:
     networks:
       - cbioportal_net
   ensembl-rest:
-    image: docker.io/nr205/ensembl-rest:109
+    image: docker.io/nr205/ensembl-rest:110
     restart: unless-stopped
     volumes:
       - ./config/ensembl_rest.conf:/opt/vep/src/ensembl-rest/ensembl_rest.conf:Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,13 +10,13 @@ services:
       NO_PROXY: "cbioportal,cbioportal_session"
       DB_PASSWORD: ${MYSQL_USER_PASSWORD:-P@ssword1}
     volumes:
-     - ./study:/study/
-     - ./config/portal.properties:/cbioportal/portal.properties:ro
-     - ./config/client-tailored-saml-idp-metadata.xml:/cbioportal-webapp/WEB-INF/classes/client-tailored-saml-idp-metadata.xml
-     - ./config/samlKeystore.jks:/cbioportal-webapp/WEB-INF/classes/samlKeystore.jks
-     - ./config/frontend.json:/cbioportal/frontend.json:ro
-     - ./config/${LOGO:-miracum.png}:/cbioportal-webapp/images/${LOGO:-miracum.png}
-     - cbioportal_portalinfo:/cbioportal/portalinfo
+     - ./study:/study/:z
+     - ./config/portal.properties:/cbioportal/portal.properties:Z
+     - ./config/client-tailored-saml-idp-metadata.xml:/cbioportal-webapp/WEB-INF/classes/client-tailored-saml-idp-metadata.xml:Z
+     - ./config/samlKeystore.jks:/cbioportal-webapp/WEB-INF/classes/samlKeystore.jks:Z
+     - ./config/frontend.json:/cbioportal/frontend.json:Z
+     - ./config/${LOGO:-miracum.png}:/cbioportal-webapp/images/${LOGO:-miracum.png}:Z
+     - cbioportal_portalinfo:/cbioportal/portalinfo:z
     depends_on:
      - cbioportal_database
      - cbioportal-session
@@ -70,9 +70,9 @@ services:
       MYSQL_USER: cbio
       MYSQL_PASSWORD: ${MYSQL_USER_PASSWORD:-P@ssword1}
     volumes:
-     - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:ro
-     - ./data/seed-cbioportal_hg19_v2.12.8.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:ro
-     - ./data/tableExtension.sql:/docker-entrypoint-initdb.d/tableExtension.sql:ro
+     - ./data/cgds.sql:/docker-entrypoint-initdb.d/cgds.sql:Z
+     - ./data/seed-cbioportal_hg19_v2.12.8.sql.gz:/docker-entrypoint-initdb.d/seed.sql.gz:Z
+     - ./data/tableExtension.sql:/docker-entrypoint-initdb.d/tableExtension.sql:Z
      - cbioportal_data:/var/lib/mysql
     command:
      - --character-set-server=latin1
@@ -111,8 +111,8 @@ services:
       FHIRSPARK_PORTALURL: http://cbioportal:8080/
       FHIRSPARK_LOGINREQUIRED: ${LOGINREQUIRED:-false}
     volumes:
-      - ./data/drugs.json:/drugs.json:ro
-      - ./data/hgnc.csv:/hgnc.csv:ro
+      - ./data/drugs.json:/drugs.json:Z
+      - ./data/hgnc.csv:/hgnc.csv:Z
     networks:
       - cbioportal_net
   hapiserver:
@@ -150,15 +150,15 @@ services:
     image: ghcr.io/buschlab/cbioproxy:${RELEASE:-latest}
     container_name: cbioproxy_container
     volumes:
-      - ./services/cbioproxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf
-      - ./services/cbioproxy/cbioportal.conf:/etc/nginx/conf.d/cbioportal.conf
-      - ./services/cbioproxy/lua_auth_config.lua:/etc/nginx/conf.d/lua_auth_config.lua
-      - ./services/cbioproxy/lua_login_config.lua:/etc/nginx/conf.d/lua_login_config.lua
-      - ./services/cbioproxy/lua_resource_config.lua:/etc/nginx/conf.d/lua_resource_config.lua
-      - ./reports:/usr/share/reports
-      - ./config/attributes.json:/attributes.json
-      - ./data/tumorTypes.json:/tumorTypes.json
-      - ./config/certs:/certs
+      - ./services/cbioproxy/nginx.conf:/usr/local/openresty/nginx/conf/nginx.conf:Z
+      - ./services/cbioproxy/cbioportal.conf:/etc/nginx/conf.d/cbioportal.conf:Z
+      - ./services/cbioproxy/lua_auth_config.lua:/etc/nginx/conf.d/lua_auth_config.lua:Z
+      - ./services/cbioproxy/lua_login_config.lua:/etc/nginx/conf.d/lua_login_config.lua:Z
+      - ./services/cbioproxy/lua_resource_config.lua:/etc/nginx/conf.d/lua_resource_config.lua:Z
+      - ./reports:/usr/share/reports:Z
+      - ./config/attributes.json:/attributes.json:Z
+      - ./data/tumorTypes.json:/tumorTypes.json:Z
+      - ./config/certs:/certs:z
     environment:
       NGINX_LOGINREQUIRED: ${LOGINREQUIRED:-false}
       KEYCLOAK_URL: ${KEYCLOAK_URL:-//localhost:8080}
@@ -210,7 +210,7 @@ services:
     image: docker.io/nr205/ensembl-rest:109
     restart: unless-stopped
     volumes:
-      - ./config/ensembl_rest.conf:/opt/vep/src/ensembl-rest/ensembl_rest.conf
+      - ./config/ensembl_rest.conf:/opt/vep/src/ensembl-rest/ensembl_rest.conf:Z
     networks:
       - cbioportal_net
     depends_on:

--- a/init.yml
+++ b/init.yml
@@ -8,8 +8,8 @@ services:
     environment:
       MYSQL_USER_PASSWORD: ${MYSQL_USER_PASSWORD:-P@ssword1}
     volumes:
-     - ./data:/data/
-     - ./config/:/config/
-     - ./init.sh:/init.sh:ro
+     - ./data:/data/:z
+     - ./config/:/config/:z
+     - ./init.sh:/init.sh:z
     command: /bin/sh -c "cd / && /init.sh"
     entrypoint: []

--- a/services/ensembl-rest/Dockerfile
+++ b/services/ensembl-rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM ensemblorg/ensembl-vep:release_103
+FROM docker.io/ensemblorg/ensembl-vep:release_109.3
 LABEL maintainer="Niklas Reimer <niklas.reimer@uksh.de>"
 
 USER root
@@ -16,7 +16,9 @@ RUN mv /opt/vep/src/ensembl-rest/ensembl_rest.conf.default /opt/vep/src/ensembl-
 
 EXPOSE 3000
 
-USER vep
+USER root
+
+#RUN chown -R root:root /
 
 WORKDIR /opt/vep/src/ensembl-vep/
 RUN ./INSTALL.pl -n -a cf -s homo_sapiens -y GRCh37

--- a/services/ensembl-rest/Dockerfile
+++ b/services/ensembl-rest/Dockerfile
@@ -1,15 +1,16 @@
-FROM docker.io/ensemblorg/ensembl-vep:release_109.3
+FROM docker.io/ensemblorg/ensembl-vep:release_110.1
 LABEL maintainer="Niklas Reimer <niklas.reimer@uksh.de>"
 
 USER root
 RUN apt-get update && apt-get install -y git libcatalyst-devel-perl libxml-simple-perl libtest-xml-simple-perl
 WORKDIR /opt/vep/src
 
-RUN git clone https://github.com/Ensembl/ensembl-compara.git
+RUN git clone https://github.com/Ensembl/ensembl-compara.git && cd ensembl-compara && git checkout release/110 && cd ..
 ENV PERL5LIB=/opt/vep/src/ensembl-vep:/opt/vep/src/ensembl-vep/modules:/opt/vep/src/ensembl-compara/modules
 
-RUN git clone https://github.com/Ensembl/ensembl-rest.git /opt/vep/src/ensembl-rest
+RUN git clone https://github.com/Ensembl/ensembl-rest.git /opt/vep/src/ensembl-rest && cd ensembl-rest && git checkout release/110 && cd ..
 WORKDIR /opt/vep/src/ensembl-rest
+RUN cpanm install --force Log::Any
 RUN cpanm --installdeps .
 
 RUN mv /opt/vep/src/ensembl-rest/ensembl_rest.conf.default /opt/vep/src/ensembl-rest/ensembl_rest.conf
@@ -18,9 +19,12 @@ EXPOSE 3000
 
 USER root
 
-#RUN chown -R root:root /
+RUN chown -R root:root /root
 
 WORKDIR /opt/vep/src/ensembl-vep/
 RUN ./INSTALL.pl -n -a cf -s homo_sapiens -y GRCh37
 
+RUN mv /root/.vep /opt/vep/
+
 ENTRYPOINT ["perl", "/opt/vep/src/ensembl-rest/script/ensembl_rest_server.pl"]
+


### PR DESCRIPTION
This PR adds support for Podman and probably other OCI compatible container engines.

Changes include:
- Add `docker.io/` prefix to all images that are stored on DockerHub (does not break compatibility with Docker!)
- Rebuild of ensembl-rest image to avoid uids >65536
  - this is useful for rootless execution and probably also helps if docker is executed in rootless mode